### PR TITLE
mISDNcapid: honour --localstatedir when setting MISDN_CAPI_SOCKET_DIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ then
 		)
 	fi
 	AC_SUBST( [MISDN_CAPI_SOCKET_NAME], "sock" )
-	AC_SUBST( [MISDN_CAPI_SOCKET_DIR], "$(localstatedir)/run/mISDNcapid" )
+	AC_SUBST( [MISDN_CAPI_SOCKET_DIR], "${localstatedir}/run/mISDNcapid" )
 fi
 
 # Checks for library functions.


### PR DESCRIPTION
Signed-off-by: Christoph Schulz <develop@kristov.de>