### PR TITLE
mISDNcapid: fix memory leak when using CAPIFLAG_HIGHJACKING

### DIFF
--- a/capi20/ncci.c
+++ b/capi20/ncci.c
@@ -1175,6 +1175,8 @@ static void ncciDataConf(struct mNCCI *ncci, struct mc_buf *mc)
 	pthread_mutex_unlock(&ncci->lock);
 	if (do_answer)
 		AnswerDataB3Req(ncci, mc, CapiNoError);
+	else
+		free_mc_buf(mc);
 	SendDataB3Down(ncci, 0);
 	return;
 }


### PR DESCRIPTION
If using a tty for sending/receiving B3 data, the mc buffer for data sent is
not freed by ncciDataConf() because this is done only by AnswerDataB3Req()
which is not called when using a tty. Fix this by explicitly freeing the mc
buffer when a tty is used.

Signed-off-by: Christoph Schulz <develop@kristov.de>