### PR TITLE
mISDNcapid: fix B channel activation

### DIFF
--- a/capi20/daemon.c
+++ b/capi20/daemon.c
@@ -1432,12 +1432,10 @@ int activate_bchannel(struct BInstance *bi)
 	struct mISDNhead mh;
 
 	mh.id = 1;
-	if (bi->proto == ISDN_P_B_RAW)
-		mh.prim = PH_ACTIVATE_REQ;
-	else if (bi->proto == ISDN_P_NONE)
+	if (bi->proto == ISDN_P_NONE)
 		return -EINVAL;
 	else
-		mh.prim = DL_ESTABLISH_REQ;
+		mh.prim = PH_ACTIVATE_REQ;
 
 	ret = send(bi->fd, &mh, sizeof(mh), 0);
 	if (ret != sizeof(mh)) {


### PR DESCRIPTION
Always sends PH_ACTIVATE_REQ and not DL_ESTABLISH_REQ down the mISDN stack when
opening a B-channel, as DL_ESTABLISH_REQ is only understood by layer-2, and
B-channel management is done at layer-1.

Signed-off-by: Christoph Schulz <develop@kristov.de>