### PR TITLE
mISDNcapid: fix lPLCIDisconnectInd() by returning zero when B3 link is missing

### DIFF
--- a/capi20/lplci.c
+++ b/capi20/lplci.c
@@ -235,7 +235,7 @@ static void lPLCIClearOtherApps(struct lPLCI *lp)
 static int lPLCIDisconnectInd(struct lPLCI *lp, struct mc_buf *mc)
 {
 	struct BInstance *bi = lp->BIlink;
-	int ret = -ENODEV;
+	int ret = 0;
 
 	if (mc && bi) {
 		lPLCICmsgHeader(lp, &mc->cmsg, CAPI_DISCONNECT, CAPI_IND);


### PR DESCRIPTION
The function lPLCIDisconnectInd() is called by plci_cc_disconnect_ind() when a
EV_L3_DISCONNECT_IND event is being handled. If the B3 link has already gone,
lPLCIDisconnectInd() returns -ENODEV, which prevents plci_cc_disconnect_ind()
from calling lPLCILinkDown() and therefore from cleaning up properly. This
commit makes lPLCIDisconnectInd() returns zero (i.e. success) in such a
situation.

Signed-off-by: Christoph Schulz <develop@kristov.de>