### PR TITLE
mISDNcapid: release B3 link properly when using CAPIFLAG_HIGHJACKING

### DIFF
--- a/capi20/lplci.c
+++ b/capi20/lplci.c
@@ -2089,6 +2089,7 @@ void B3ReleaseLink(struct lPLCI *lp, struct BInstance *bi)
 {
 	switch(bi->type) {
 	case BType_Direct:
+	case BType_tty:
 		ncciReleaseLink(bi->b3data);
 		break;
 #ifdef USE_SOFTFAX


### PR DESCRIPTION
Until now, B3ReleaseLink() did not care about BType_tty B3 links. This commit
makes them behave like BType_Direct links.

Signed-off-by: Christoph Schulz <develop@kristov.de>