### PR TITLE
Signal handlers

### DIFF
--- a/capi20/m_capi.h
+++ b/capi20/m_capi.h
@@ -57,6 +57,7 @@ extern pid_t	gettid(void);
 #define MICD_CTRL_SHUTDOWN	0x42010000
 #define MICD_CTRL_DISABLE_POLL	0x42020000
 #define MICD_CTRL_ENABLE_POLL	0x42030000
+#define MICD_CTRL_REOPEN_LOG	0x42040000
 
 int send_master_control(int, int, void *);
 

--- a/capi20/m_capi.h
+++ b/capi20/m_capi.h
@@ -58,6 +58,8 @@ extern pid_t	gettid(void);
 #define MICD_CTRL_DISABLE_POLL	0x42020000
 #define MICD_CTRL_ENABLE_POLL	0x42030000
 #define MICD_CTRL_REOPEN_LOG	0x42040000
+#define MICD_CTRL_DUMP_1	0x42050000
+#define MICD_CTRL_DUMP_2	0x42060000
 
 int send_master_control(int, int, void *);
 


### PR DESCRIPTION
Create signal handler for SIGHUP that re-opens the debug log file. This is required e.g. when the logfile has been rotated by logrotate.

While doing so, we noticed that quite a few unsafe function calls are contained in signal handlers, so we moved these to other places in the code. Calling functions other than those listed in "man 7 signal" can result in undefined behaviour and crahes that are hard to debug.

We have been running this code on our machines for quite a while now without any trouble.