### PR TITLE
mISDNcapid: remove irritating timeout warning

### DIFF
--- a/capi20/daemon.c
+++ b/capi20/daemon.c
@@ -1016,9 +1016,9 @@ static void *BCthread(void *arg)
 			continue;
 		}
 		if (ret == 0) { /* timeout */
-			wprint("Bchannel%d %stimeout (release %spending) thread=%05d\n", bi->nr,
-				bi->got_timeout ? "2. " : "", bi->release_pending ? "" : "not ", bi->tid);
 			if (bi->release_pending) {
+				wprint("Bchannel%d %stimeout (release pending) thread=%05d\n", bi->nr,
+					bi->got_timeout ? "2. " : "", bi->tid);
 				if (bi->got_timeout) { /* 2 times */
 					bi->detached = 1;
 					ret = pthread_detach(bi->thread);


### PR DESCRIPTION
The loop within BCthread() continuously emits a warning like the following one

  BCthread(24062):Bchannel1 timeout (release not pending) thread=24062

every 500 ms as long as no data is received over the B-channel. This is very
irritating and noisy and fills up the log file without a good reason. This
commit lets the warning be shown only if the timeout occurs while a release
operation is pending (and this is worth a warning because such a timeout does
not occur under normal circumstances).